### PR TITLE
Fix unnecessary `de` output.

### DIFF
--- a/docker-fzf
+++ b/docker-fzf
@@ -231,8 +231,6 @@ de() {
           *)
             command='sh'
             command=" ash; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
-            command="bash; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
-            command=" zsh; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
         esac
 
         command="sh -c '$command'"


### PR DESCRIPTION
This commit removes the attempts to run `bash` and `zsh` with the
rationale that running `sh` or `ash` suffices for almost all containers.

Fixes #6 