### PR TITLE
Avoid "not found" output if e.g. zsh isn't available within the container

### DIFF
--- a/docker-fzf
+++ b/docker-fzf
@@ -229,10 +229,10 @@ de() {
           ;;
 
           *)
-            command='sh'
-            command=" ash; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
-            command="bash; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
-            command=" zsh; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
+            command='command -v sh &> /dev/null 2>&1 && sh'
+            command="command -v ash &> /dev/null 2>&1 && ash || ( $command )"
+            command="command -v bash &> /dev/null 2>&1 && bash || ( $command )"
+            command="command -v zsh  &> /dev/null 2>&1 && zsh || ( $command )"
         esac
 
         command="sh -c '$command'"


### PR DESCRIPTION
Avoid "not found" output if e.g. zsh isn't available within the docker container

Fixes #6