### PR TITLE
Avoid "not found" output if e.g. zsh isn't available within the container

### DIFF
--- a/docker-fzf
+++ b/docker-fzf
@@ -229,10 +229,7 @@ de() {
           ;;
 
           *)
-            command='sh'
-            command=" ash; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
-            command="bash; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
-            command=" zsh; if [ \"\$?\" -eq \"127\" ]; then $command; fi"
+            command='command $(command -v zsh || command -v bash || command -v ash || command -v sh)'
         esac
 
         command="sh -c '$command'"


### PR DESCRIPTION
Avoid "not found" output if e.g. zsh isn't available within the docker container

Fixes #6