### PR TITLE
Rework `drmi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,33 +16,33 @@ Feel free to create a PR with improvements - but please keep this documentation 
 
 # Overview of available commands
 
-| command | description                                               | fzf mode | command arguments (optional)                                                                                 |
-| ------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
-| dr      | docker restart && open logs (in follow mode)              | multiple |                                                                                                              |
-| dl      | docker logs (in follow mode)                              | multiple | time interval - e.g.: `1m` for 1 minute - (defaults to all available logs)                                   |
-| dla     | docker logs (in follow mode) all containers               |          | time interval - e.g.: `1m` for 1 minute - (defaults to all available logs)                                   |
-| de      | docker exec in interactive mode                           | single   | command to exec (default - see below)                                                                        |
-| drm     | docker remove container (with force)                      | multiple |                                                                                                              |
-| drma    | docker remove all containers (with force)                 |          |                                                                                                              |
-| ds      | docker stop                                               | multiple |                                                                                                              |
-| dsa     | docker stop all running containers                        |          |                                                                                                              |
-| dsrm    | docker stop and remove container                          | multiple |                                                                                                              |
-| dsrma   | docker stop and remove all container                      |          |                                                                                                              
-| dk      | docker kill                                               | multiple |                                                                                                              |
-| dka     | docker kill all containers                                |          |                                                                                                              |
-| dkrm    | docker kill and remove container                          | multiple |                                                                                                              |
-| dkrma   | docker kill and remove all container                      |          |                                                                                                              |
-| drmi    | docker remove image (with force)                          | multiple |                                                                                                              |
-| drmia   | docker remove all images (with force)                     |          |                                                                                                              |
-| dclean  | `dsrma` and `drmia`                                       |          |                                                                                                              |
-| dcu     | docker-compose up (in detached mode)                      | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
-| dcua    | docker-compose up all services (in detached mode)         |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
-| dcb     | docker-compose build (with --no-cache and --pull)         | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
-| dcba    | docker-compose build (with --no-cache and --pull) all     |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
-| dcp     | docker-compose pull                                       | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
-| dcpa    | docker-compose pull all services                          |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
-| dcupd   | docker-compose update image (rebuild or pull)             | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
-| dcupda  | `dcba` and `dcpa`                                         |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| command | description                                                                        | fzf mode | command arguments (optional)                                                                                 |
+| ------- | ---------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| dr      | docker restart && open logs (in follow mode)                                       | multiple |                                                                                                              |
+| dl      | docker logs (in follow mode)                                                       | multiple | time interval - e.g.: `1m` for 1 minute - (defaults to all available logs)                                   |
+| dla     | docker logs (in follow mode) all containers                                        |          | time interval - e.g.: `1m` for 1 minute - (defaults to all available logs)                                   |
+| de      | docker exec in interactive mode                                                    | single   | command to exec (default - see below)                                                                        |
+| drm     | docker remove container (with force)                                               | multiple |                                                                                                              |
+| drma    | docker remove all containers (with force)                                          |          |                                                                                                              |
+| ds      | docker stop                                                                        | multiple |                                                                                                              |
+| dsa     | docker stop all running containers                                                 |          |                                                                                                              |
+| dsrm    | docker stop and remove container                                                   | multiple |                                                                                                              |
+| dsrma   | docker stop and remove all container                                               |          |                                                                                                              
+| dk      | docker kill                                                                        | multiple |                                                                                                              |
+| dka     | docker kill all containers                                                         |          |                                                                                                              |
+| dkrm    | docker kill and remove container                                                   | multiple |                                                                                                              |
+| dkrma   | docker kill and remove all container                                               |          |                                                                                                              |
+| drmi    | docker remove image (with force). This includes options to remove dangling images. | multiple |                                                                                                              |
+| drmia   | docker remove all images (with force). This includes dangling images.              |          |                                                                                                              |
+| dclean  | `dsrma` and `drmia`                                                                |          |                                                                                                              |
+| dcu     | docker-compose up (in detached mode)                                               | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| dcua    | docker-compose up all services (in detached mode)                                  |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| dcb     | docker-compose build (with --no-cache and --pull)                                  | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| dcba    | docker-compose build (with --no-cache and --pull) all                              |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| dcp     | docker-compose pull                                                                | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| dcpa    | docker-compose pull all services                                                   |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| dcupd   | docker-compose update image (rebuild or pull)                                      | multiple | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
+| dcupda  | `dcba` and `dcpa`                                                                  |          | path to docker-compose file (defaults to recursive search for `docker-compose.yml` or `docker-compose.yaml`) |
 
 ## Default command for `de`
 The command used to `exec` into a container is dependent on the base image.

--- a/docker-fzf
+++ b/docker-fzf
@@ -339,13 +339,141 @@ dkrma() {
 
 #docker remove image
 drmi() {
-  __docker_images_pre_test \
-    && docker images --format "{{.Repository}}:{{.Tag}}" --filter "dangling=false" \
-      | fzf -m \
-      | while read -r ref; do
-          local id=$(docker images --filter "reference=$ref" --format "{{.ID}}")
-          docker rmi $id -f
-        done
+  __docker_images_pre_test;
+  if [ "$?" -eq "0" ]; then
+    echo "Loading images. Depending on the number of images you have, this may take a while...";
+
+    #column1: comma seperated list of ids to be removed if this option is selected
+    #column2: text to be displayed to the user.
+    #seperator: tab ("\t")
+    local images='';
+
+    # create image references for non-dangling images
+    for id in $(docker images --format "{{.ID}}" --filter "dangling=false" | sort | uniq); do
+      local references=$(docker inspect "$id" --format "{{range .RepoTags}}{{.}}\n{{end}}{{range .RepoDigests}}{{.}}\n{{end}}");
+
+      local list=$(echo "$references" | sed 's/\\n$//' | sed -r 's/\\n/\n/g');
+      local listLength=$(echo "$list" | wc -l);
+      local head=$(echo "$list" | head -n 1);
+      local tail=$(echo "$list" | tail -n 1);
+
+      local result="$id\t";
+      for ref in $(echo "$list"); do
+        if [[ "$head" == "$ref" ]]; then
+          result+="$ref";
+          if [[ "$listLength" == "2" ]]; then
+            result+=" (alias: ";
+          elif [[ "$listLength" != "1" ]]; then
+            result+=" (aliases: ";
+          fi;
+        elif [[ "$tail" == "$ref" ]]; then
+            result+="$ref)";
+        else
+            result+="$ref, ";
+        fi;
+      done;
+
+      if [[ "$images" == "" ]]; then
+        images="$result";
+      else
+        images+="\n$result";
+      fi
+    done;
+
+  # create image references for dangling images
+    local ids=$(docker images --format "{{.ID}}" --filter "dangling=true");
+    local numberOfIds=$(echo "$ids" | wc -l)
+    if [[ "$numberOfIds" != "0" ]]; then
+      #add option to remove all dangling images
+      local allDanglingImages=$(echo -e "$ids" | sed ':a; N; s/\n/,/; ta'); # join all ids into CSV list
+      allDanglingImages+="\tAll dangling images (total of $numberOfIds)";
+      if [[ "$images" == "" ]]; then
+        images="$allDanglingImages";
+      else
+        images+="\n$allDanglingImages";
+      fi
+
+      #group by label
+      local idCreatedLabel='';
+      for id in $(echo "$ids" | head -n 20); do
+        local created=$(docker inspect "$id" --format "{{.Created}}");
+        local labels=$(docker inspect "$id" --format '{{ range $key, $value := .Config.Labels }}{{ $key }}:{{$value}}\n{{end}}');
+
+        while read -r label; do #also entered for no label
+          local reference=$(echo -e "$id\t$created\t$label");
+          if [[ "$idCreatedLabel" == "" ]]; then
+            idCreatedLabel="$reference";
+          else
+            idCreatedLabel+="\n$reference";
+          fi
+        done <<< "$(echo "$labels" | sed 's/\\n$//' | sed -r 's/\\n/\n/g')";
+      done;
+
+      local awk=''
+      #$1=id
+      #$2=created date
+      #$3=label
+      #a = all ids that belong to label
+      #b = max created date
+      #c = max created id
+      awk+='{'
+      awk+='a[$3]=a[$3] ? a[$3]","$1 : $1' #create a CSV list of ids (grouped by label)
+      awk+=';'
+      awk+='if(!b[$3] || b[$3] < $2) {' #if the current row created date is bigger than all dates in previous rows
+      awk+='b[$3]=$2' #set date
+      awk+=';'
+      awk+='c[$3]=$1' #set id
+      awk+='}'
+      awk+='}'
+      awk+='END'
+      awk+='{'
+      awk+='for (i in a){'
+      awk+='print (i ? i : "none")"\t"a[i]"\t"c[i]' #replace no label with "none" here, as otherwise the splitting of columns didn't work below
+      awk+='}'
+      awk+='}'
+      while read -r labelIdsLatestId; do
+        local label="$(echo -e "$labelIdsLatestId" | cut -f 1)"
+        local allIds="$(echo -e "$labelIdsLatestId" | cut -f 2)"
+        local numberOfIds="$(echo "$allIds" | awk -F ',' '{print NF}')"
+        local latestBuildId="$(echo -e "$labelIdsLatestId" | cut -f 3)"
+
+        local labelReference="";
+        if [[ "$label" == "none" ]]; then #see awk
+          labelReference='that have no label';
+        else
+          labelReference="that have the label $label";
+        fi;
+
+        local imagesPluralOrSingular="image"
+        if [[ "$numberOfIds" != "1" ]]; then
+          imagesPluralOrSingular+="s";
+        fi;
+
+        images+="\n$allIds\tAll dangling $imagesPluralOrSingular (total of $numberOfIds) $labelReference"
+
+        if [[ "$numberOfIds" != "1" ]]; then
+          local idsWithoutLatest="$(echo "$allIds" | sed -r "s/(^$latestBuildId,|,$latestBuildId)//")"
+
+          imagesPluralOrSingular="image"
+          if [[ "$numberOfIds" != "2" ]]; then #2 because the number of ids still includes the id to keep (newest created date)
+            imagesPluralOrSingular+="s";
+          fi;
+
+          images+="\n$idsWithoutLatest\tAll EXCEPT THE NEWEST dangling $imagesPluralOrSingular (total of $((numberOfIds-1))) $labelReference"
+        fi;
+      done <<< "$(echo -e "$idCreatedLabel" | awk -F "\t" "$awk")"
+    fi;
+
+    echo -e "$images" \
+      | fzf -m -d "\t" --with-nth=2 \
+      | cut -f 1 \
+      | sed 's/,/\n/g' \
+      | sort \
+      | uniq \
+      | while read -r idToRemove; do
+          docker rmi "$idToRemove"
+        done;
+  fi;
 }
 
 #docker remove all images

--- a/docker-fzf
+++ b/docker-fzf
@@ -349,16 +349,16 @@ drmi() {
     local images='';
 
     # create image references for non-dangling images
-    for id in $(docker images --format "{{.ID}}" --filter "dangling=false" | sort | uniq); do
+    for id in $(docker images --format "{{.ID}}" --filter "dangling=false" | sort | uniq); do #remove duplicate ids. necessary because each image tag has an entry, and images may have multiple tags
       local references=$(docker inspect "$id" --format "{{range .RepoTags}}{{.}}\n{{end}}{{range .RepoDigests}}{{.}}\n{{end}}");
 
-      local list=$(echo "$references" | sed 's/\\n$//' | sed -r 's/\\n/\n/g');
+      local list=$(echo "$references" | sed 's/\\n$//' | sed -r 's/\\n/\n/g'); #remove trailing new line && replace \n with actual new line
       local listLength=$(echo "$list" | wc -l);
       local head=$(echo "$list" | head -n 1);
       local tail=$(echo "$list" | tail -n 1);
 
       local result="$id\t";
-      for ref in $(echo "$list"); do
+      for ref in $(echo -e "$list"); do
         if [[ "$head" == "$ref" ]]; then
           result+="$ref";
           if [[ "$listLength" == "2" ]]; then
@@ -393,7 +393,7 @@ drmi() {
         images+="\n$allDanglingImages";
       fi
 
-      #group by label
+      #add options, group by label
       local idCreatedLabel='';
       for id in $(echo "$ids" | head -n 20); do
         local created=$(docker inspect "$id" --format "{{.Created}}");
@@ -406,7 +406,7 @@ drmi() {
           else
             idCreatedLabel+="\n$reference";
           fi
-        done <<< "$(echo "$labels" | sed 's/\\n$//' | sed -r 's/\\n/\n/g')";
+        done <<< "$(echo "$labels" | sed 's/\\n$//' | sed -r 's/\\n/\n/g')"; #remove trailing new line && replace \n with actual new line
       done;
 
       local awk=''
@@ -417,19 +417,23 @@ drmi() {
       #b = max created date
       #c = max created id
       awk+='{'
-      awk+='a[$3]=a[$3] ? a[$3]","$1 : $1' #create a CSV list of ids (grouped by label)
-      awk+=';'
-      awk+='if(!b[$3] || b[$3] < $2) {' #if the current row created date is bigger than all dates in previous rows
-      awk+='b[$3]=$2' #set date
-      awk+=';'
-      awk+='c[$3]=$1' #set id
-      awk+='}'
+        awk+='a[$3]=a[$3] ? a[$3]","$1 : $1' #create a CSV list of ids (grouped by label)
+        awk+=';'
+        awk+='if(!b[$3] || b[$3] < $2){' #if the current row created date is bigger than all dates in previous rows
+          awk+='b[$3]=$2' #set date
+          awk+=';'
+          awk+='c[$3]=$1' #set id
+        awk+='}'
       awk+='}'
       awk+='END'
       awk+='{'
-      awk+='for (i in a){'
-      awk+='print (i ? i : "none")"\t"a[i]"\t"c[i]' #replace no label with "none" here, as otherwise the splitting of columns didn't work below
-      awk+='}'
+        awk+='for (i in a){'
+          awk+='print (i ? i : "none")' #replace no label with "none" here, as otherwise the splitting of columns didn't work below
+          awk+='"\t"'
+          awk+='a[i]'
+          awk+='"\t"'
+          awk+='c[i]'
+        awk+='}'
       awk+='}'
       while read -r labelIdsLatestId; do
         local label="$(echo -e "$labelIdsLatestId" | cut -f 1)"
@@ -438,7 +442,7 @@ drmi() {
         local latestBuildId="$(echo -e "$labelIdsLatestId" | cut -f 3)"
 
         local labelReference="";
-        if [[ "$label" == "none" ]]; then #see awk
+        if [[ "$label" == "none" ]]; then #see awk. since labels always contain key and value (seperated by a colon), this is safe
           labelReference='that have no label';
         else
           labelReference="that have the label $label";
@@ -464,6 +468,8 @@ drmi() {
       done <<< "$(echo -e "$idCreatedLabel" | awk -F "\t" "$awk")"
     fi;
 
+    #column1 contains ids. multiple ids per line may be comma seperated
+    #because there may be an overlap in dangling image ids, remove duplicates.
     echo -e "$images" \
       | fzf -m -d "\t" --with-nth=2 \
       | cut -f 1 \

--- a/docker-fzf
+++ b/docker-fzf
@@ -409,32 +409,30 @@ drmi() {
         done <<< "$(echo "$labels" | sed 's/\\n$//' | sed -r 's/\\n/\n/g')"; #remove trailing new line && replace \n with actual new line
       done;
 
-      local awk=''
       #$1=id
       #$2=created date
       #$3=label
       #a = all ids that belong to label
       #b = max created date
       #c = max created id
-      awk+='{'
-        awk+='a[$3]=a[$3] ? a[$3]","$1 : $1' #create a CSV list of ids (grouped by label)
-        awk+=';'
-        awk+='if(!b[$3] || b[$3] < $2){' #if the current row created date is bigger than all dates in previous rows
-          awk+='b[$3]=$2' #set date
-          awk+=';'
-          awk+='c[$3]=$1' #set id
-        awk+='}'
-      awk+='}'
-      awk+='END'
-      awk+='{'
-        awk+='for (i in a){'
-          awk+='print (i ? i : "none")' #replace no label with "none" here, as otherwise the splitting of columns didn't work below
-          awk+='"\t"'
-          awk+='a[i]'
-          awk+='"\t"'
-          awk+='c[i]'
-        awk+='}'
-      awk+='}'
+      # shellcheck disable=SC2016
+      local awk='
+      {
+        a[$3] = a[$3] ? a[$3]","$1 : $1; #create a CSV list of ids (grouped by label)
+
+        if( !b[$3] || b[$3] < $2 ) { #if the current row created date is bigger than all dates in previous rows
+          b[$3] = $2; #set date
+          c[$3] = $1; #set id
+        }
+      } END {
+        for ( i in a ) {
+          print (i ? i : "none") #replace no label with "none" here, as otherwise the splitting of columns didnt work below
+          "\t"
+          a[i]
+          "\t"
+          c[i];
+        }
+      }'
       while read -r labelIdsLatestId; do
         local label="$(echo -e "$labelIdsLatestId" | cut -f 1)"
         local allIds="$(echo -e "$labelIdsLatestId" | cut -f 2)"


### PR DESCRIPTION
* If an image has multiple tags, the current version shows each tag on a new line. Now, all tags are shown together on one line, together with the digest(s). e.g.: `my-image:latest (aliases: my-image:1.0.0, my-image@sha256:a3d2...)`.
* You now have the option to remove all dangling images via a new entry: `All dangling images (total of 140)`
* If you are using labels during the build process, you may also distinguish dangling images via labels. Lets assume you add a label `name=my-service` to a dockerfile and build it 10 times. You now have two new options:
  * `All dangling images (total of 10) with the label name:my-service`
  * `All EXCEPT THE NEWEST dangling images (total of 9) with the label name:my-service`

fixes #8